### PR TITLE
chore: accept new Cruft update

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/kjaymiller/cookiecutter-relecloud/",
-  "commit": "a3794bddf382c4c6fa4add5bf935ca14bca40a71",
+  "commit": "d507bca0f2f67be7274add230496456327acef14",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python3 -m uvicorn fastapi_app:app --reload --port=8000
 
     ```sh
     python3 -m pip install -r requirements-dev.in
-    playwright install --with-deps
+    python3 -m playwright install --with-deps
     ```
 
 3. Run the tests:

--- a/src/fastapi_app/models.py
+++ b/src/fastapi_app/models.py
@@ -9,8 +9,9 @@ POSTGRES_USERNAME = os.environ.get("POSTGRES_USERNAME")
 POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD")
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST")
 POSTGRES_DATABASE = os.environ.get("POSTGRES_DATABASE")
+POSTGRES_PORT = os.environ.get("POSTGRES_PORT")
 
-sql_url = f"postgresql://{POSTGRES_USERNAME}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}/{POSTGRES_DATABASE}"
+sql_url = f"postgresql://{POSTGRES_USERNAME}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DATABASE}"
 
 if os.environ.get("POSTGRES_SSL", "disable") != "disable":
     sql_url = f"{sql_url}?sslmode=require"

--- a/src/fastapi_app/seed_data.py
+++ b/src/fastapi_app/seed_data.py
@@ -50,6 +50,9 @@ def load_from_json():
 
 
 def drop_all():
+    # Explicitly remove these tables first to avoid cascade errors
+    SQLModel.metadata.remove(models.Cruise.__table__)
+    SQLModel.metadata.remove(models.Destination.__table__)
     SQLModel.metadata.drop_all(models.engine)
 
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,27 +1,53 @@
+import socket
+import time
 from multiprocessing import Process
 
 import pytest
+import requests
 import uvicorn
 
 from fastapi_app import seed_data
 from fastapi_app.app import app
 
 
-def run_server():
-    uvicorn.run(app)
+def wait_for_server_ready(url: str, timeout: float = 10.0, check_interval: float = 0.5) -> bool:
+    """Make requests to provided url until it responds without error."""
+    conn_error = None
+    for _ in range(int(timeout / check_interval)):
+        try:
+            requests.get(url)
+        except requests.ConnectionError as exc:
+            time.sleep(check_interval)
+            conn_error = str(exc)
+        else:
+            return True
+    raise RuntimeError(conn_error)
 
 
 @pytest.fixture(scope="session")
-def live_server():
+def free_port() -> int:
+    """
+    Return a free port on localhost
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        addr = s.getsockname()
+        port = addr[1]
+        return port
+
+
+def run_server(port):
+    uvicorn.run(app, port=port)
+
+
+@pytest.fixture(scope="session")
+def live_server_url(free_port: int):
+    """Returns the url of the live server"""
     seed_data.load_from_json()
-    proc = Process(target=run_server, daemon=True)
+    proc = Process(target=run_server, args=(free_port,), daemon=True)
     proc.start()
-    yield
+    url = f"http://localhost:{free_port}"
+    wait_for_server_ready(url, timeout=10.0, check_interval=0.5)
+    yield url
     proc.kill()
     seed_data.drop_all()
-
-
-@pytest.fixture(scope="session")
-def live_server_url(live_server):
-    """Returns the url of the live server"""
-    return "http://localhost:8000"


### PR DESCRIPTION
This pull request includes changes to improve the functionality and usability of the codebase, including adding a `wait_for_server_ready` function to ensure the server is ready before running tests, modifying the `drop_all` function to avoid cascade errors, and updating the installation command for Playwright in the `README.md` file.

Main interface changes:

* <a href="diffhunk://#diff-d693b2faa093742e7045e9d6606e499d5ff59a8c9625968286d5abf230c28e35R1-R53">`src/tests/conftest.py`</a>: Added `wait_for_server_ready` function to ensure server is ready before running tests, modified `live_server` fixture to use this function, and added `free_port` function to generate a free port on localhost to run the server on.

Bug fixes:

* <a href="diffhunk://#diff-4c69a14915c63960152224cf2894f90ce3d8ee39cc5a2744568d06a6406dfb11R53-R55">`src/fastapi_app/seed_data.py`</a>: Modified `drop_all` function to avoid cascade errors when dropping all tables.

Configuration improvements:

* <a href="diffhunk://#diff-7b1438cc5a871699533a558b896508c905226be2ee0f8aab1ebd6d2795e79f5eL3-R3">`.cruft.json`</a>: Updated `commit` field to `d507bca0f2f67be7274add230496456327acef14`.

Documentation improvements:

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R58">`README.md`</a>: Updated the installation command for Playwright to use `python3 -m playwright` instead of `playwright`.

Minor improvements:

* <a href="diffhunk://#diff-3965c5a1bd55f206de5999a7dd2749408351b7440bdeb18abfe7eed087bbc733R12-R14">`src/fastapi_app/models.py`</a>: Modified `sql_url` variable to include `POSTGRES_PORT` environment variable in the URL.